### PR TITLE
Change HTTP verb to "GET" for listing pipelines

### DIFF
--- a/resources/QUICKSTART.md
+++ b/resources/QUICKSTART.md
@@ -30,7 +30,7 @@
 ## SDC Edge commands via REST API
 
 ### List all pipelines
-    curl -X POST http://localhost:18633/rest/v1/pipelines
+    curl -X GET http://localhost:18633/rest/v1/pipelines
 
 ### Start Pipeline
     curl -X POST http://localhost:18633/rest/v1/pipeline/:pipelineId/start


### PR DESCRIPTION
The QUICKSTART.md stated, that "curl -X POST http://localhost:18633/rest/v1/pipelines" would list available pipelines, which returns "method not allowed". The correct HTTP verb would be "GET".